### PR TITLE
Update db details as old db is non-existent

### DIFF
--- a/spark/credit-risk/meta/credit-risk-meta.json
+++ b/spark/credit-risk/meta/credit-risk-meta.json
@@ -576,14 +576,14 @@
       {
         "connection": {
           "db": "BLUDB", 
-          "host": "dashdb-entry-yp-dal09-09.services.dal.bluemix.net", 
-          "password": "G_2jp_K2avMY", 
-          "username": "dash11348"
+          "host": "dashdb-txn-sbox-yp-dal09-03.services.dal.bluemix.net", 
+          "password": "khhz72v+6mcwwkfv", 
+          "username": "cmb91569"
         }, 
         "name": "German credit risk training data", 
         "source": {
           "tablename": "CREDIT_RISK_TRAIN_DATA", 
-          "type": "dashdb"
+          "type": "db2"
         }
       }
     ]


### PR DESCRIPTION
The entry plan databases aren't going to be supported going forward. For the time being updating credentials of my instance until we find an WOS common account to provision the DB and use it